### PR TITLE
Vertically aligned person icon next to userid in user menu.

### DIFF
--- a/app/assets/stylesheets/components/user/user-bar.sass
+++ b/app/assets/stylesheets/components/user/user-bar.sass
@@ -86,6 +86,19 @@
           max-height: 22px
           margin: 17px 0 17px 0.5rem
           vertical-align: middle
+      
+      &.flex
+        display: flex
+
+        &.align-center
+          align-items: center
+
+        .no-grow
+          flex-grow: 0
+        
+        .flex-grow-1
+          flex-grow: 1
+
 
     .logo
       padding: 0 15px 0 0

--- a/app/javascript/components/NavBar/UserMenu.js
+++ b/app/javascript/components/NavBar/UserMenu.js
@@ -42,13 +42,17 @@ class UserMenu extends Component {
       >
         <ul className="dropdown-menu">
           <li>
-            <Link to={'/' + user.username} data-testid={'user-profile-link'}>
-              <i className="material-icons left">
-                {identity.characterId !== null ? 'people' : 'person'}
-              </i>
-              <span>{identity.name}</span>
-              <br />
-              <span className="muted">@{user.username}</span>
+            <Link className="flex align-center" to={'/' + user.username} data-testid={'user-profile-link'}>
+              <div className="no-grow">
+                <i className="material-icons left">
+                  {identity.characterId !== null ? 'people' : 'person'}
+                </i>
+              </div>
+              <div className="flex-grow-1">
+                <span>{identity.name}</span>
+                <br />
+                <span className="muted">@{user.username}</span>
+              </div>
             </Link>
           </li>
 


### PR DESCRIPTION
Quick UI bug that has been driving me a bit crazy.  The icon didn't line up on the user drop down so I updated the layout of that entry to allow for vertical alignment independent of the size of the content to it's immediate right.  Attached are images with approximate center lines on the icon to show the change.

**Pre change** the icon was aligned with the top and thus first line:
<img width="227" alt="Pre Change" src="https://user-images.githubusercontent.com/22208211/99749584-d1f26f80-2aac-11eb-9575-5a36c133f8e0.png">

**Post change** the icon is vertically centered on the whole entry and looks much better in my opinion:
<img width="175" alt="Post Change" src="https://user-images.githubusercontent.com/22208211/99750185-ebe08200-2aad-11eb-8983-40e4fe0020c5.png">


Note: This is my first PR to this repo and thus a simple change.  I hope to contribute more in the future.

